### PR TITLE
Improve UI with navigation and landing page

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -6,8 +6,15 @@
     <title>{% block title %}Cadastro de Servidores{% endblock %}</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
 </head>
-<body class="bg-gray-100">
-    <div class="container mx-auto p-4">
+<body class="bg-gray-100 min-h-screen flex flex-col">
+    <nav class="bg-blue-600 text-white">
+        <div class="container mx-auto px-4 py-3 flex space-x-4">
+            <a href="{{ url_for('index') }}" class="font-semibold hover:underline">Início</a>
+            <a href="{{ url_for('cadastro') }}" class="hover:underline">Cadastrar</a>
+            <a href="{{ url_for('listagem') }}" class="hover:underline">Listagem</a>
+        </div>
+    </nav>
+    <div class="container mx-auto p-4 flex-grow">
         {% block content %}{% endblock %}
     </div>
 </body>

--- a/templates/cadastro.html
+++ b/templates/cadastro.html
@@ -2,19 +2,21 @@
 {% block title %}Cadastrar Servidor{% endblock %}
 {% block content %}
 <h2 class="text-xl font-semibold mb-4">Cadastrar Servidor</h2>
-<form class="space-y-4" method="post" action="{{ url_for('cadastro') }}">
-    <div>
-        <label class="block">Nome:</label>
-        <input class="border rounded w-full p-2" type="text" name="nome" required>
-    </div>
-    <div>
-        <label class="block">Email:</label>
-        <input class="border rounded w-full p-2" type="email" name="email" required>
-    </div>
-    <div>
-        <label class="block">Telefone:</label>
-        <input class="border rounded w-full p-2" type="text" name="telefone" required>
-    </div>
-    <button class="bg-blue-500 text-white px-4 py-2 rounded" type="submit">Salvar</button>
-</form>
+<div class="max-w-md mx-auto bg-white p-6 rounded shadow">
+    <form class="space-y-4" method="post" action="{{ url_for('cadastro') }}">
+        <div>
+            <label class="block mb-1 font-medium">Nome:</label>
+            <input class="border rounded w-full p-2" type="text" name="nome" required>
+        </div>
+        <div>
+            <label class="block mb-1 font-medium">Email:</label>
+            <input class="border rounded w-full p-2" type="email" name="email" required>
+        </div>
+        <div>
+            <label class="block mb-1 font-medium">Telefone:</label>
+            <input class="border rounded w-full p-2" type="text" name="telefone" required>
+        </div>
+        <button class="bg-blue-500 text-white px-4 py-2 rounded w-full" type="submit">Salvar</button>
+    </form>
+</div>
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,9 +1,12 @@
 {% extends 'base.html' %}
 {% block title %}Home - Cadastro de Servidores{% endblock %}
 {% block content %}
-<h1 class="text-2xl font-bold mb-4">Cadastro de Servidores</h1>
-<ul class="space-y-2">
-    <li><a class="text-blue-500" href="{{ url_for('cadastro') }}">Cadastrar Servidor</a></li>
-    <li><a class="text-blue-500" href="{{ url_for('listagem') }}">Listar Servidores</a></li>
-</ul>
+<div class="text-center py-16">
+    <h1 class="text-4xl font-bold mb-4">Bem-vindo ao Cadastro de Servidores</h1>
+    <p class="mb-8 text-lg text-gray-700">Gerencie seus servidores de forma simples e rápida.</p>
+    <div class="space-x-4">
+        <a class="bg-blue-500 text-white px-4 py-2 rounded" href="{{ url_for('cadastro') }}">Cadastrar Servidor</a>
+        <a class="bg-gray-200 px-4 py-2 rounded" href="{{ url_for('listagem') }}">Listar Servidores</a>
+    </div>
+</div>
 {% endblock %}

--- a/templates/listagem.html
+++ b/templates/listagem.html
@@ -2,7 +2,8 @@
 {% block title %}Listagem de Servidores{% endblock %}
 {% block content %}
 <h2 class="text-xl font-semibold mb-4">Servidores Cadastrados</h2>
-<table class="min-w-full bg-white">
+<div class="bg-white p-6 rounded shadow">
+<table class="min-w-full">
     <thead>
         <tr>
             <th class="py-2 px-4 border">Nome</th>
@@ -24,4 +25,5 @@
         {% endfor %}
     </tbody>
 </table>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add navigation menu to the base layout
- redesign index into a landing page
- improve cadastro form style
- wrap listagem table in card

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684b2e64c8f48321a6a35e044c0462d8