### PR TITLE
Add organograma route

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ python app.py
 ```
 
 Acesse `http://localhost:5000` para abrir a página inicial, onde você poderá cadastrar e listar servidores e departamentos.
+
+## Organograma
+
+Utilize a rota `/organograma` para visualizar um organograma dinâmico com todos os departamentos e seus respectivos servidores.

--- a/app.py
+++ b/app.py
@@ -104,5 +104,29 @@ def listagem_departamentos():
     departamentos = Departamento.query.all()
     return render_template('listagem_departamentos.html', departamentos=departamentos)
 
+
+@app.route('/organograma')
+def organograma():
+    departamentos = Departamento.query.all()
+    servidores = Servidor.query.all()
+
+    nodes = []
+
+    # Add root department
+    nodes.append({'name': config.DEPARTAMENTO_SUPERIOR, 'parent': ''})
+
+    # Add departments
+    for dep in departamentos:
+        if dep.nome == config.DEPARTAMENTO_SUPERIOR:
+            continue
+        parent = dep.departamento_superior if dep.departamento_superior != dep.nome else config.DEPARTAMENTO_SUPERIOR
+        nodes.append({'name': dep.nome, 'parent': parent})
+
+    # Add servers
+    for servidor in servidores:
+        nodes.append({'name': servidor.nome, 'parent': servidor.departamento.nome})
+
+    return render_template('organograma.html', nodes=nodes)
+
 if __name__ == '__main__':
     app.run(debug=True)

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,6 +14,7 @@
             <a href="{{ url_for('listagem') }}" class="hover:underline">Listagem de Servidores</a>
             <a href="{{ url_for('cadastro_departamento') }}" class="hover:underline">Cadastrar Departamento</a>
             <a href="{{ url_for('listagem_departamentos') }}" class="hover:underline">Departamentos</a>
+            <a href="{{ url_for('organograma') }}" class="hover:underline">Organograma</a>
         </div>
     </nav>
     <div class="container mx-auto p-4 flex-grow">

--- a/templates/organograma.html
+++ b/templates/organograma.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+{% block title %}Organograma{% endblock %}
+{% block content %}
+<h2 class="text-xl font-semibold mb-4">Organograma</h2>
+<div id="chart_div"></div>
+<script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+<script>
+  google.charts.load('current', {packages:['orgchart']});
+  google.charts.setOnLoadCallback(drawChart);
+  function drawChart() {
+    var data = new google.visualization.DataTable();
+    data.addColumn('string', 'Name');
+    data.addColumn('string', 'Manager');
+    data.addColumn('string', 'ToolTip');
+    data.addRows([
+{% for node in nodes %}
+      [{v:'{{ node.name }}', f:'{{ node.name }}'}, '{{ node.parent }}', '{{ node.name }}'],
+{% endfor %}
+    ]);
+    var chart = new google.visualization.OrgChart(document.getElementById('chart_div'));
+    chart.draw(data, {allowHtml:true});
+  }
+</script>
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- create organograma route to render Google Charts org chart
- add new template and navigation link
- document feature in README

## Testing
- `python -m py_compile app.py`
- ❌ `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684b33fd43bc83219b28ff717953cccb